### PR TITLE
Issue #2 - Workaround to preserve disk configuration

### DIFF
--- a/CsmakeModules/ConvertVirtualImage.py
+++ b/CsmakeModules/ConvertVirtualImage.py
@@ -1,20 +1,5 @@
 # <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
-# <copyright>
+# (c) Copyright 2018 Cardinal Peak Technologies
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # This program is free software: you can redistribute it and/or modify it
@@ -57,6 +42,8 @@ class ConvertVirtualImage(CsmakeModule):
                vmdk-image - vmdk disk image (vmWare)
                vdi-image - vdi disk image (VirtualBox)
                qcow2-image - qcow2 disk image (KVM)
+               vhdx-image - vhdx-image (Hyper V)
+               vpc-image - vhd-image (Hyper V older format)
            (Eventually, it would be nice to be able to
             specify multiple parts 1-* and *-1)
        Requires:

--- a/CsmakeModules/CopyRawImage.py
+++ b/CsmakeModules/CopyRawImage.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeModule import CsmakeModule
 import subprocess
 import os.path

--- a/CsmakeModules/HLinuxConfigApt.py
+++ b/CsmakeModules/HLinuxConfigApt.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from CsmakeModules.ShellEnv import ShellEnv
 import os
 import os.path

--- a/CsmakeModules/InjectDiskUsedToIndex.py
+++ b/CsmakeModules/InjectDiskUsedToIndex.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeModule import CsmakeModule
 import os
 import os.path

--- a/CsmakeModules/ModifyVmdkDDB.py
+++ b/CsmakeModules/ModifyVmdkDDB.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeModule import CsmakeModule
 import shutil
 import os.path

--- a/CsmakeModules/MountDiskDrivePartitions.py
+++ b/CsmakeModules/MountDiskDrivePartitions.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeAspect import CsmakeAspect
 import subprocess
 import os.path

--- a/CsmakeModules/SystemBuild.py
+++ b/CsmakeModules/SystemBuild.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeAspect import CsmakeModule
 import re
 

--- a/CsmakeModules/SystemBuildDisk.py
+++ b/CsmakeModules/SystemBuildDisk.py
@@ -74,6 +74,7 @@ class SystemBuildDisk(CsmakeModule):
             return
         diskEntry = systemEntry['disks'][self.diskname]
         device = diskEntry['device']
+        diskPath = diskEntry['path']
         result = subprocess.call(
             ['sudo', 'losetup', '-d', device],
             stdout=self.log.out(),

--- a/CsmakeModules/SystemBuildDisk.py
+++ b/CsmakeModules/SystemBuildDisk.py
@@ -1,4 +1,5 @@
 # <copyright>
+# (c) Copyright 2018 Cardinal Peak Technologies
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # This program is free software: you can redistribute it and/or modify it
@@ -80,6 +81,19 @@ class SystemBuildDisk(CsmakeModule):
         del systemEntry['disks'][self.diskname]
         if result != 0:
             self.log.warning("Deleting device '%s' failed", device)
+        result = subprocess.call(
+            ['cp', '--sparse=always', diskPath, diskPath + '.save'],
+            stdout=self.log.out(),
+            stderr=self.log.err())
+        if result != 0:
+            self.log.warning("Copy of device '%s' failed", device)
+        else:
+            result = subprocess.call(
+                ['mv', diskPath + '.save', diskPath],
+                stdout=self.log.out(),
+                stderr=self.log.err())
+            if result != 0:
+                self.log.warning("Move of save disk '%s' failed", device)
 
     def system_build(self, options):
         return self.build(options)

--- a/CsmakeModules/SystemBuildEnd.py
+++ b/CsmakeModules/SystemBuildEnd.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeModule import CsmakeModule
 from CsmakeModules.SystemBuild import SystemBuild
 import os

--- a/CsmakeModules/SystemBuildGrubInstall.py
+++ b/CsmakeModules/SystemBuildGrubInstall.py
@@ -1,4 +1,5 @@
 # <copyright>
+# (c) Copyright 2018 Cardinal Peak Technologies
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # This program is free software: you can redistribute it and/or modify it
@@ -201,9 +202,15 @@ class SystemBuildGrubInstall(CsmakeModule):
         # TODO: Currently this only works for ms-dos partition tables
         #      Also, assumes only MBR grub install
         #      Change it to work with GPT and UEFI as well
+        grub_install = 'grub-install'
+        try:
+            subprocess.check_call(['sudo', 'chroot', self.systemPartition, 'which', 'grub2-install'])
+            grub_install = 'grub2-install'
+        except:
+            pass
         result = subprocess.call(
             ["sudo", "chroot", self.systemPartition,
-                "grub-install" ] + self.GRUB_OPTIONS + [ self.systemDevice ],
+                grub_install, '--target', 'i386-pc'] + self.GRUB_OPTIONS + [ self.systemDevice ],
             stdout=self.log.out(),
             stderr=self.log.err())
         if result != 0:

--- a/CsmakeModules/SystemBuildMount.py
+++ b/CsmakeModules/SystemBuildMount.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeAspect import CsmakeAspect
 import subprocess
 import os.path

--- a/CsmakeModules/SystemBuildPopulateFstab.py
+++ b/CsmakeModules/SystemBuildPopulateFstab.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeModule import CsmakeModule
 import subprocess
 import os.path

--- a/CsmakeModules/SystemBuildUnmount.py
+++ b/CsmakeModules/SystemBuildUnmount.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeModule import CsmakeModule
 from CsmakeModules.SystemBuildMount import SystemBuildMount
 import os

--- a/CsmakeModules/TarballRawDisk.py
+++ b/CsmakeModules/TarballRawDisk.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeModule import CsmakeModule
 import subprocess
 import os

--- a/CsmakeModules/UnmountDiskDrivePartitions.py
+++ b/CsmakeModules/UnmountDiskDrivePartitions.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeModule import CsmakeModule
 from CsmakeModules.MountDiskDrivePartitions import MountDiskDrivePartitions
 import os

--- a/CsmakeModules/UntarballRawDisk.py
+++ b/CsmakeModules/UntarballRawDisk.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from Csmake.CsmakeModule import CsmakeModule
 import subprocess
 

--- a/CsmakeModules/VersionedPackager.py
+++ b/CsmakeModules/VersionedPackager.py
@@ -14,22 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # </copyright>
-# <copyright>
-# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-# Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# </copyright>
 from CsmakeModules.Packager import Packager
 import os.path
 import os

--- a/csmakefile
+++ b/csmakefile
@@ -1,4 +1,5 @@
 # <copyright>
+# (c) Copyright 2018 Cardinal Peak Technologies
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # This program is free software: you can redistribute it and/or modify it
@@ -26,26 +27,26 @@ test=Run testing for csmake
 
 [metadata@csmake-system-build]
 name=csmake-system-build
-version=1.0.13
+version=1.0.15
 description=csmake library enabling building out systems
 about=csmake library providing various modules that cooperate
  to enable the building of full compute system disks capable of
  multiple devices, partitioning, lvm, grub, etc., as well as modules
  to allow for the ability to create various kinds of vm disks and export
  types (ova).
-packager=Jeremiah Patterson <jerpat@hpe.com>
-manufacturer=Hewlett Packard Enterprise
-#Rpm support and package name translation doesn't support package logical
-#  operators (csmake:GH Issue 24, csmake-packaging:GH Issue 2)
-#  Just continue to package and support qemu-img for now...CentOS 7 is back
-#  on 1.5 ... oy vez...2.9 is out (and can be built with the csmake spec
-#  in the packaged-dependents directory)
-#depends=python (>= 2.6), csmake, qemu-img | qemu-utils, vbox-img
-depends=python (>= 2.6), csmake, qemu-img, vbox-img
+packager=Jeremiah Patterson <jerry@casecracker.com>
+manufacturer=Cardinal Peak Technologies
+#Be sure to list qemu-img first so that rpm sees it as a dependency
+#  Logical operator support is not there for rpm yet, so it takes the
+#  first listed package.
+# Ubuntu 16.04 can use qemu-utils or qemu-img because qemu-img
+#   in 16.04's qemu-utils is new enough to handle desired formats
+depends=python (>= 2.6), csmake, qemu-img | qemu-utils, vbox-img
+#depends=python (>= 2.6), csmake, qemu-img, vbox-img
 recommends=python-coverage, chrpath
 suggests=csmake-providers
 keywords=make build development system vm
-copyrights=csmake-copyright
+copyrights=csmake-copyright, csmake-cpt-copyright
 classifiers=
     Development Status :: 4 - Beta
     Intended Audience :: Developers
@@ -78,12 +79,17 @@ license=GPLv3
 holder=Hewlett Packard Enterprise
 years=2014-2017
 
+[copyright@csmake-cpt-copyright]
+license=GPLv3
+holder=Cardinal Peak Technologies
+years=2018
+
 [DebianPackage@debian-csmake]
 package-version=1.0
 default_python-script={root}/usr/bin/
 maps=csmake-installs
 result=%(RESULTS)s/debpackage
-debian-directory-copyright=csmake-copyright
+debian-directory-copyright=csmake-cpt-copyright
 
 [Signature@default-signature]
 [RpmPackage@rpm-csmake]
@@ -119,7 +125,7 @@ group_root=root
 
 map_CsmakeModules=
    map: <CsmakeModules> -(1-1)-> {PYTHON}/CsmakeSystemBuild/CsmakeModules/{~~file~~}}
-   copyright: csmake-copyright
+   copyright: csmake-copyright, csmake-cpt-copyright
    owner:{root}
    group:{root}
    permissions:644


### PR DESCRIPTION
This does a cp --sparse=always and a mv back to ensure
   that anything that happens to the loop device after
   the disk is supposed to be cleaned up and detached from the device
   is not performed against the disk.

It takes 2x disk space to do it this way and more time to do the
   copy.  I'd really like to understand why the loop device
   is holding the file open until all the lvs are destroyed.